### PR TITLE
Fix: Stations page

### DIFF
--- a/src/app/admin/pages/stations/components/station-form/station-form.component.html
+++ b/src/app/admin/pages/stations/components/station-form/station-form.component.html
@@ -47,34 +47,34 @@
   </mat-form-field>
 
   <ng-container formArrayName="relations">
-    @for (control of relations.controls; track createId()) {
+    @for (control of relations.controls; track createId(); let i = $index) {
       <mat-form-field
         appearance="outline"
         subscriptSizing="dynamic"
         floatLabel="always"
       >
-        @if ($index === 0) {
+        @if ($first) {
           <mat-label>Connected</mat-label>
         }
 
-        <mat-select [formControlName]="$index">
+        <mat-select [formControlName]="i" (selectionChange)="onSetConnected(i)">
           @for (station of stations(); track station.id) {
             <mat-option [value]="station.id">{{ station.city }}</mat-option>
           }
         </mat-select>
 
-        @if ($index !== 0) {
+        @if (!$last) {
           <button
             mat-icon-button
             matSuffix
             type="button"
-            (click)="removeField($index)"
+            (click)="removeField(i)"
           >
             <mat-icon>close</mat-icon>
           </button>
         }
 
-        @if (relations.controls.at($index)?.errors?.["required"]) {
+        @if (relations.controls.at(i)?.errors?.["required"]) {
           <mat-error>Required</mat-error>
         }
       </mat-form-field>
@@ -83,15 +83,6 @@
     @if (relations.hasError("nonUnique")) {
       <mat-error>Stations must be unique</mat-error>
     }
-
-    <button
-      class="form-control"
-      mat-raised-button
-      type="button"
-      (click)="addField()"
-    >
-      add another city
-    </button>
   </ng-container>
   <button
     class="form-control"

--- a/src/app/admin/pages/stations/components/station-form/station-form.component.ts
+++ b/src/app/admin/pages/stations/components/station-form/station-form.component.ts
@@ -47,7 +47,7 @@ export class StationFormComponent {
       longitude: [0, [Validators.max(180), Validators.min(-180)]],
 
       relations: this.formBuilder.array(
-        [this.formBuilder.control<number | null>(null, Validators.required)],
+        [this.formBuilder.control<number | null>(null)],
         this.uniqueRelationsValidator,
       ),
     },
@@ -130,8 +130,15 @@ export class StationFormComponent {
     return this.stationForm.get('relations') as FormArray;
   }
 
-  addField(): void {
-    const city = this.formBuilder.control(null, Validators.required);
+  onSetConnected(fieldIdx: number) {
+    const lastFieldIdx = this.relations.length - 1;
+    if (fieldIdx === lastFieldIdx) {
+      this.addField();
+    }
+  }
+
+  private addField(): void {
+    const city = this.formBuilder.control(null);
     this.relations.push(city);
   }
 
@@ -144,9 +151,10 @@ export class StationFormComponent {
   }
 
   async createStation() {
-    const newStation = mapFormToStation(
-      this.stationForm.value as StationFormData,
-    );
+    const newStation = mapFormToStation({
+      ...this.stationForm.value,
+      relations: this.relations.value.filter((item: number | null) => !!item),
+    } as StationFormData);
 
     await this.stationStore.addStation(newStation);
 


### PR DESCRIPTION
Acceptance Criteria 2: Connecting stations
- The page must allow the manager to connect the new station to other stations. It is dynamic number of items, **selecting one item the next form field appears**.

**Before:**
![image](https://github.com/user-attachments/assets/5009889b-8e42-4df0-b713-56511b39f805)

**After:**
![image](https://github.com/user-attachments/assets/03f359e1-c8d7-4cab-8232-16ae9a955aee)
